### PR TITLE
Update push methods, tests, readme and add f11s

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ dataset = f11s.Dataset({'name': dataset_name})
 dataset.add_resource(resource)
 
 # Push the dataset and resources to CKAN and resources to cloud cloud
-res = client_obj.push(dataset.descriptor)
+res = client_obj.push(dataset)
 # res = [{
 #     'oid': ...
 #     'size': ...

--- a/README.md
+++ b/README.md
@@ -38,21 +38,43 @@ $ pip install requirements.txt
 
 ## Developers
 ```bash
+from ckan_sdk import f11s
 from ckan_sdk import client
 
-client_obj = client.Client(endpoint, token_api_key, organization_name, dataset_name)
+client_obj = client.Client(endpoint, auth_token, organization_name)
 
-## Porcelain
-client_obj.push('path-to-resource')
+# loads a resource from a path
+resource = f11s.load(resource_file_path)
+# resource = {
+#     name: ...
+#     path: ...
+#     hash: ...
+#     size: ...
+#   }
 
-# you can also push a set of files
-# if directory we search for all *.csv ...
-client_obj.push_resources(resources)
+dataset = f11s.Dataset({'name': dataset_name})
+dataset.add_resorce(resource)
 
-## Plumbing
-client_obj.store_blob()
-client_obj.push_resource_metadata() # resource_update
-client_obj.push_dataset_metadata()  # package_update
+# Push the dataset and resources to CKAN and resources to cloud cloud
+res = client_obj.push(dataset.descriptor)
+# res = [{
+#     'oid': ...
+#     'size': ...
+#     'success': ...
+#     'file_already_exists': ...
+#     'dataset': ...
+#     }]
+
+# To push a single resource to ckan and cloud
+# `append` specifies that dataset already exists
+res = client.push_resource(resource, dataset='dataset-name', append=True)
+# res = [{
+#     'oid': ...
+#     'size': ...
+#     'success': ...
+#     'file_already_exists': ...
+#     'dataset': ...
+#     }]
 ```
 
 ## Design

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ res = client_obj.push(dataset.descriptor)
 
 # To push a single resource to ckan and cloud
 # `append` specifies that dataset already exists
-res = client.push_resource(resource, dataset='dataset-name', append=True)
+res = client.push_resource(resource_path, dataset='dataset-name', append=True)
 # res = [{
 #     'oid': ...
 #     'size': ...

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ resource = f11s.load(resource_file_path)
 #   }
 
 dataset = f11s.Dataset({'name': dataset_name})
-dataset.add_resorce(resource)
+dataset.add_resource(resource)
 
 # Push the dataset and resources to CKAN and resources to cloud cloud
 res = client_obj.push(dataset.descriptor)
@@ -65,6 +65,8 @@ res = client_obj.push(dataset.descriptor)
 #     'dataset': ...
 #     }]
 
+
+resource_path = 'path/to/file'
 # To push a single resource to ckan and cloud
 # `append` specifies that dataset already exists
 res = client.push_resource(resource_path, dataset='dataset-name', append=True)

--- a/ckan_sdk/f11s.py
+++ b/ckan_sdk/f11s.py
@@ -1,0 +1,41 @@
+import os
+import hashlib
+
+
+def load(file_path):
+    # Return a descriptor of the file
+
+    file_descriptor = {}
+
+    file_descriptor['name'] = os.path.basename(file_path)
+
+    file_descriptor['path'] = file_path
+
+    stat_obj = os.stat(file_path)
+    file_descriptor['size'] = stat_obj.st_size
+
+    sha256 = hashlib.sha256()
+    with open(file_path, 'rb') as file:
+        for block in iter(lambda: file.read(50000), b''):
+            sha256.update(block)
+
+        file_descriptor['hash'] = sha256.hexdigest()
+
+    return file_descriptor
+
+
+class Dataset:
+    '''
+    This is a class for creating a dataset
+
+    Attributes:
+        descriptor (dict): dict object of a dataset description
+    '''
+
+    def __init__(self, descriptor={}):
+        self.descriptor = descriptor
+
+    def add_resource(self, resource_descriptor):
+        self.descriptor['resources'] = []
+        self.descriptor['resources'].append(resource_descriptor)
+        return resource_descriptor

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,13 +3,13 @@ from urllib.parse import urljoin
 import mock
 
 from ckan_sdk.client import Client
+from ckan_sdk import f11s
 
 
 config = {
   'auth_token': 'f75160d3-a876-4b43-8a6f-2dc7a693031f',
   'base_url': 'http://127.0.0.1:5000',
   'organization_id': 'test-org',
-  'dataset_id': 'xloader_dataset',
 }
 
 access_granter_config = {
@@ -36,14 +36,12 @@ access_granter_config = {
 ckan_uploader = Client(config['base_url'],
                 config['auth_token'],
                 config['organization_id'],
-                config['dataset_id'],
             )
 
 def test_can_instantiate_uploader():
     datahub = Client(config['base_url'],
                 config['auth_token'],
                 config['organization_id'],
-                config['dataset_id'],
             )
     assert datahub.base_url == config['base_url']
 
@@ -87,14 +85,52 @@ request_file_upload_actions_json = {
               ],
           }
 
+dataset_resp = {
+  'result': {
+    'id': 'abc-123-xyz-321',
+    'name': 'test-dataset',
+    'owner_org': 'test-org'
+    }
+  }
+resource_resp = {
+  'result': {
+    'id': 'abc-123-xyz-321',
+    'size': 1691,
+    'hash': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    'path': './tests/sample_file/dailyprices.csv'
+    }
+  }
+
 @mock.patch("ckan_sdk.client.Client.get_jwt_from_ckan_authz", return_value=get_jwt_from_ckan_authz_json)
 @mock.patch("ckan_sdk.client.Client.request_file_upload_actions", return_value=request_file_upload_actions_json)
 @mock.patch("ckan_sdk.client.Client.upload_to_storage", return_value=True)
 @mock.patch("ckan_sdk.client.Client.verify_upload", return_value=True)
-def test_push_works_with_packaged_dataset(get_jwt_from_ckan_authz_mock, request_file_upload_actions_mock,
-                                          upload_to_storage_mock, verify_upload_mock):
+@mock.patch("ckan_sdk.client.Client._ckan_package_or_resource_create", side_effect = [dataset_resp, resource_resp])
+def test_push(get_jwt_from_ckan_authz_mock, request_file_upload_actions_mock,
+                                          upload_to_storage_mock, verify_upload_mock
+                                          ,_ckan_package_or_resource_create_mock):
 
-    result = ckan_uploader.push('./tests/sample_file/dailyprices.csv')
+    resource = f11s.load('./tests/sample_file/dailyprices.csv')
+    dataset = f11s.Dataset({'name': 'test-dataset'})
+    dataset.add_resource(resource)
+    result = ckan_uploader.push(dataset.descriptor)[0]
+
+    assert result['success'] == True
+    assert result['size'] == 1691
+    assert result['oid'] == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+@mock.patch("ckan_sdk.client.Client.get_jwt_from_ckan_authz", return_value=get_jwt_from_ckan_authz_json)
+@mock.patch("ckan_sdk.client.Client.request_file_upload_actions", return_value=request_file_upload_actions_json)
+@mock.patch("ckan_sdk.client.Client.upload_to_storage", return_value=True)
+@mock.patch("ckan_sdk.client.Client.verify_upload", return_value=True)
+@mock.patch("ckan_sdk.client.Client._ckan_package_or_resource_create", return_value = resource_resp)
+@mock.patch("ckan_sdk.client.Client._get_ckan_dataset", return_value = dataset_resp)
+def test_push_resource_with_existing_dataset(get_jwt_from_ckan_authz_mock, request_file_upload_actions_mock,
+                                          upload_to_storage_mock, verify_upload_mock,
+                                          _ckan_package_or_resource_create_mock,
+                                          _get_ckan_dataset_mock):
+
+    result = ckan_uploader.push_resource('./tests/sample_file/dailyprices.csv', 'test-dataset')[0]
 
     assert result['success'] == True
     assert result['size'] == 1691

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -113,7 +113,7 @@ def test_push(get_jwt_from_ckan_authz_mock, request_file_upload_actions_mock,
     resource = f11s.load('./tests/sample_file/dailyprices.csv')
     dataset = f11s.Dataset({'name': 'test-dataset'})
     dataset.add_resource(resource)
-    result = ckan_uploader.push(dataset.descriptor)[0]
+    result = ckan_uploader.push(dataset)[0]
 
     assert result['success'] == True
     assert result['size'] == 1691


### PR DESCRIPTION
Issue #6 

- Update `push()` now it can push dataset and resource to CKAN and then push resources to the cloud.
- Add `push_resource()`, it is to a single resource to ckan and cloud (apeend=True) means in an existing dataset.
- Add `f11s` which contains a load method for loading a resource and a Dataset class.
- Update test_client.py
- Update readme
