### PR TITLE
Fix/refactor client

### DIFF
--- a/ckan_sdk/client.py
+++ b/ckan_sdk/client.py
@@ -181,7 +181,7 @@ class Client:
             'Authorization': self.auth_token,
         }
 
-        body = {'scopes': scope}
+        body = json.dumps({'scopes': scope})
         url = urljoin(self.base_url, path)
         response = self.__make_ckan_post_request(url, body, headers)
 
@@ -206,7 +206,7 @@ class Client:
         dict: contains the json response of the request.
         '''
 
-        body = {
+        body = json.dumps({
                 'operation': 'upload',
                 'transfers': ['basic'],
                 'ref': { 'name': 'refs/heads/contrib' },
@@ -216,13 +216,13 @@ class Client:
                     'size': file_size,
                     },
                 ],
-            }
+            })
 
         headers = {
             'Accept': 'application/vnd.git-lfs+json',
             'Content-Type': 'application/vnd.git-lfs+json',
             'Authorization': 'Bearer {}'.format(jwt_auth_token),
-        },
+        }
 
         url = urljoin(self.base_url, path)
         response = self.__make_ckan_post_request(url, body, headers)
@@ -291,7 +291,7 @@ class Client:
         return True
 
     def __make_ckan_post_request(self, url, body, headers):
-        return requests.post(url, body, headers=headers)
+        return requests.post(url, data=body, headers=headers)
 
     def __make_ckan_put_request(self, url, body, headers):
         return requests.put(url, body, headers=headers)


### PR DESCRIPTION
In this PR:

-  added `json.dupms()` wraper to request body, like:

```
body = json.dumps({
                'operation': 'upload',
                'transfers': ['basic'],
                'ref': { 'name': 'refs/heads/contrib' },
                'objects': [
                    {
                    'oid': file_hash,
                    'size': file_size,
                    },
                ],
            })
``` 

- removed unnecessary comma after `headers` that caused a run time error:
```
...
headers = {
            'Accept': 'application/vnd.git-lfs+json',
            'Content-Type': 'application/vnd.git-lfs+json',
            'Authorization': 'Bearer {}'.format(jwt_auth_token),
        } ,
```