### PR TITLE
Fix `client.action` POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![ckan-client-py actions](https://github.com/datopian/ckan-client-py/workflows/ckan-client-py%20actions/badge.svg)](https://github.com/datopian/ckan-client-py/actions?query=workflow%3A%22ckan-client-py+actions%22)
 [![The MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 
-CKAN SDK for interacting with CKAN instances with [CKAN v3 style cloud storage][storage]. Tutorial on use at https://tech.datopian.com/ckan-client-guide/. API documentation below. 
+CKAN SDK for interacting with CKAN instances with [CKAN v3 style cloud storage][storage]. Tutorial on use at https://tech.datopian.com/ckan-client-guide/. API documentation below.
 
 </div>
 
@@ -42,8 +42,8 @@ from ckanclient import Client
 
 
 client = Client(
-    '771a05ad-af90-4a70-beea-cbb050059e14',
     'http://localhost:5000',
+    '771a05ad-af90-4a70-beea-cbb050059e14',
     'datopian',
     'dailyprices',
     'http://localhost:9419',

--- a/ckanclient/__init__.py
+++ b/ckanclient/__init__.py
@@ -88,7 +88,7 @@ class Client:
             params = {camel_to_snake(k): v for k, v in payload.items()}
             response = requests.get(url, headers=headers, params=params)
         else:
-            response = requests.post(url, headers=headers, data=payload)
+            response = requests.post(url, headers=headers, json=payload)
 
         if response.status_code < 200 or response.status_code >= 300:
             raise CkanClientError(response)


### PR DESCRIPTION
Currently `client.action` is sending the payload using the `data` parameter which sends it in a `key=value&key_2=value_2` format causing CKAN to return an error:

```
"Bad request - JSON Error: Error decoding JSON data. Error: <BadRequest '400: Bad Request'> JSON data extracted from the request: {}"
```

**Fix:** 
Use `json` parameter instead.

